### PR TITLE
sound: fix pygame import when no pygame installed

### DIFF
--- a/xoinvader/sound.py
+++ b/xoinvader/sound.py
@@ -46,9 +46,12 @@ class DummyMixer(object):
 class PygameMixer(object, metaclass=Singleton):
     """Handle sound files."""
 
-    import pygame
-
     def __init__(self):
+        # TODO: make 'sound' package alike 'application'
+        # TODO: import appropriate sound class from separate files
+        import pygame
+        self.pygame = pygame  # Do not try it home
+
         self.pygame.mixer.init()
 
         self._sounds = dict()


### PR DESCRIPTION
**Closes issue(s):** [ ]

**Description of the changes:**

Class variables assignment executes on import time, I prevented importing pygame if it no needed everywhere except this place, now it fixed.

  * What's new:
  * Fixes: fix pygame import when `-ns` option to xoigame provided
  * Refactoring:

**Reviewers:** [ @taptap ]

**Task list:**

- [x] submit pull request
- [ ] review
- [ ] testing
- [ ] fixes after review, squashing, rebasing to master
