### PR TITLE
tests: skip test with pygame mocking when no pygame provided

### DIFF
--- a/xoinvader/tests/common.py
+++ b/xoinvader/tests/common.py
@@ -36,3 +36,14 @@ class StateMock(State):
 class AnotherStateMock(StateMock):
     """Class for test with two instances."""
     pass
+
+
+def no_pygame():
+    """Test if pygame accessible of not."""
+
+    try:
+        import pygame  # noqa
+    except ImportError:
+        return True
+
+    return False

--- a/xoinvader/tests/test_application.py
+++ b/xoinvader/tests/test_application.py
@@ -1,6 +1,5 @@
 """xoinvader.application.Application unit test."""
 
-import pygame
 import pytest
 
 from xoinvader import constants
@@ -8,9 +7,8 @@ from xoinvader.common import Settings
 import xoinvader.curses_utils
 from xoinvader.application import get_application, Application
 from xoinvader.application.ncurses_app import CursesApplication
-from xoinvader.application.pygame_app import PygameApplication
 
-from xoinvader.tests.common import StateMock, AnotherStateMock
+from xoinvader.tests.common import StateMock, AnotherStateMock, no_pygame
 
 
 def test_application():
@@ -56,8 +54,13 @@ def test_curses_application(monkeypatch):
     assert _test_application_loop(app)
 
 
+@pytest.mark.skipif(no_pygame(), reason="Pygame is not accessible")
 def test_pygame_application(monkeypatch):
     """xoinvader.application.PygameApplication"""
+
+    import pygame
+
+    from xoinvader.application.pygame_app import PygameApplication
 
     monkeypatch.setattr(pygame, "init", lambda: (0, 6))
     monkeypatch.setattr(pygame, "quit", lambda: True)


### PR DESCRIPTION
**Closes issue(s):** [ #39 ]

**Description of the changes:**

  * What's new:
  * Fixes: skip test that imports pygame if pygame is not accessible
  * Refactoring:

**Reviewers:** [ @taptap ]

**Task list:**

- [x] submit pull request
- [ ] review
- [ ] testing
- [ ] fixes after review, squashing, rebasing to master
