### PR TITLE
background: use __len__ for chunk length, minor style fixes

### DIFF
--- a/xoinvader/background.py
+++ b/xoinvader/background.py
@@ -15,14 +15,11 @@ class Chunk(object):
 
     :param str name: name of the chunk
     :param list lines: list of all chunk lines
-    :param int length: length of lines list (for convenience)
-
     """
 
     def __init__(self, name):
         self._name = name
         self._lines = []
-        self._length = 0
 
     @property
     def name(self):
@@ -32,23 +29,21 @@ class Chunk(object):
     def lines(self):
         return self._lines
 
-    @property
-    def length(self):
-        return self._length
-
     def add_line(self, line):
-        """Add line to `lines` list of the chunk. Increases `length` by 1.
+        """Add line to `lines` list of the chunk.
 
         :param str line: line to add
         """
         self._lines.append(line)
-        self._length += 1
 
     def __getitem__(self, index):
         return self._lines[index]
 
     def __setitem__(self, index, item):
         self._lines[index] = item
+
+    def __len__(self):
+        return len(self._lines)
 
 
 def load_chunks(filename, trim_width=None):
@@ -93,7 +88,7 @@ def load_chunks(filename, trim_width=None):
                 chunks.append(current_chunk)
                 names.append(name)
                 continue
-            elif not current_chunk:
+            elif current_chunk is None:
                 continue
             # ok, now we got both chunk and something to store in it
             line_add = line[:trim_width] if trim_width else line
@@ -246,7 +241,7 @@ class Background(Renderable):
             return " " * self._w
 
         # start checks
-        if (self._chunk_line < self._current_chunk.length and
+        if (self._chunk_line < len(self._current_chunk) and
                 self._chunk_line >= 0):
             line = self._current_chunk[self._chunk_line]
             self._chunk_line += advance
@@ -255,7 +250,7 @@ class Background(Renderable):
         # chunk ended! now we decide what to do
         if self._loop:
             if self._chunk_line < 0:
-                self._chunk_line = self._current_chunk.length - 1
+                self._chunk_line = len(self._current_chunk) - 1
             else:
                 self._chunk_line = 0
             line = self._current_chunk[self._chunk_line]
@@ -277,7 +272,7 @@ class Background(Renderable):
             if self._current_chunk_num < 0:
                 self._current_chunk_num = len(self._chunks) - 1
                 self._current_chunk = self._chunks[-1]
-                self._chunk_line = self._current_chunk.length - 1
+                self._chunk_line = len(self._current_chunk) - 1
             else:
                 self._current_chunk_num = 0
                 self._current_chunk = self._chunks[0]

--- a/xoinvader/tests/test_background.py
+++ b/xoinvader/tests/test_background.py
@@ -11,12 +11,12 @@ PREFIX = "xoinvader/tests/fixtures/"
 def test_chunk():
     c = Chunk("test")
     assert not c.lines
-    assert not c.length
+    assert len(c) == 0
     assert c.name == "test"
 
     c.add_line("wut")
     assert c.lines[0] == "wut"
-    assert c.length == 1
+    assert len(c) == 1
 
     c[0] = "ugh"
     assert c[0] == "ugh"
@@ -35,7 +35,7 @@ def test_load_chunks():
     c = load_chunks(PREFIX + "chunk_normal.bg")
     assert len(c) == 3
     assert c[0][0] == "qweqwe"
-    assert c[0].length == 1
+    assert len(c[0]) == 1
 
     d = load_chunks(PREFIX + "chunk_normal.bg", 3)
     assert d[0][0] == "qwe"
@@ -67,7 +67,7 @@ def test_background():
 
     b = Background(PREFIX + "chunk_normal.bg")
     assert len(b.chunks) == 3
-    assert len(b.chunks[2].lines) == 3
+    assert len(b.chunks[2]) == 3
 
     b.start()
     assert b._current_chunk is b.chunks[0]

--- a/xoinvader/tests/test_background.py
+++ b/xoinvader/tests/test_background.py
@@ -3,10 +3,11 @@ from copy import copy
 
 from xoinvader.background import Background, Chunk, load_chunks
 from xoinvader.common import Settings
-from xoinvader.utils import Point, Surface
+from xoinvader.utils import Point
 
 
 PREFIX = "xoinvader/tests/fixtures/"
+
 
 def test_chunk():
     c = Chunk("test")
@@ -113,16 +114,16 @@ def test_background():
     assert b._advance_chunk(1) == "!@#"
     assert b._advance_chunk(1) == "   "
 
-    P, S = b.get_render_data()
-    assert P == [Point(0,0)]
-    assert next(S) == (Point(0,0,0), "q", None)
-    assert next(S) == (Point(1,0,0), "w", None)
-    assert next(S) == (Point(2,0,0), "e", None)
-    assert next(S) == (Point(0,1,0), "a", None)
-    assert next(S) == (Point(1,1,0), "s", None)
-    assert next(S) == (Point(2,1,0), "d", None)
+    pos, gen = b.get_render_data()
+    assert pos == [Point(0, 0)]
+    assert next(gen) == (Point(0, 0, 0), "q", None)
+    assert next(gen) == (Point(1, 0, 0), "w", None)
+    assert next(gen) == (Point(2, 0, 0), "e", None)
+    assert next(gen) == (Point(0, 1, 0), "a", None)
+    assert next(gen) == (Point(1, 1, 0), "s", None)
+    assert next(gen) == (Point(2, 1, 0), "d", None)
     with pytest.raises(StopIteration):
-        next(S)
+        next(gen)
 
     assert not b.update()
     b.speed = 40


### PR DESCRIPTION
* Use __len__ for providing length of inner list
    This is common python approach. len calls __len__ of countable object.
* Use valid variable names in test instead of P and S, remove unused import.

**Closes issue(s):** [  ]

**Description of the changes:**

  * What's new:
  * Fixes:
  * Refactoring:

**Reviewers:** [ @taptap ]

**Task list:**

- [x] submit pull request
- [x] review
- [x] testing
- [x] fixes after review, squashing, rebasing to master
