### PR TITLE
Init add colliders

### DIFF
--- a/xoinvader/collision.py
+++ b/xoinvader/collision.py
@@ -1,49 +1,215 @@
-"""Collision detection."""
+"""Collision detection system and component module."""
+
+import weakref
+
+from xoinvader.utils import Point
 
 
-class SettingsManager(object):
+class TypePair(object):
+    """Class for hashable unordered string pairs.
 
-    def __init__(self, settings_map={}):
-        self._smap = settings_map
+    Used as collision dictionary keys, containing pair of collider types. It's
+    set-like, i.e. TypePair(a, b) == TypePair(b, a) and their hashes are equal
+    too.
 
-    def notify(self, owner, settings):
-        self._smap[owner].update(settings)
+    :param str first: first collider type
+    :param str second: second collider type
+    """
+
+    def __init__(self, first, second):
+        first, second = sorted([first, second])
+        self._first = first
+        self._second = second
+        self._pair = first + '_' + second
+
+    @property
+    def first(self):
+        return self._first
+
+    @property
+    def second(self):
+        return self._second
+
+    def __eq__(self, other):
+        return self._pair == other._pair
+
+    def __hash__(self):
+        return hash(self._pair)
 
 
-class UpdatableSettings(object):
+class CollisionManager(object):
+    """Class for collision detection between known components.
 
-    def __init__(self, settings_manager, settings={}):
-        self._settings = settings
-        self._settings_manager = settings_manager
+    To process collisions, first update the positions of all objects of
+    interest, then call `update` method. It will traverse all registered
+    collisions (between pairs of types) and call appropriate handlers in order
+    they were registered for the two types of colliding objects.
 
-    def updateInstanceSettings(self, settings):
-        self._settings.update(settings)
+    If you just want to check, if two Colliders collide, call `check_collision`
+    on them.
+    """
 
-    def notifySettingsManager(self):
-        self._settings_manager.notify(self.__class__.__name__, settings)
+    # Marker of solid matter inside collider physics map
+    __solid_matter__ = "#"
+
+    def __init__(self):
+        if Collider.__manager__ is None:
+            def null_manager(_):
+                Collider.__manager__ = None
+            Collider.__manager__ = weakref.ref(self, null_manager)
+        self._colliders = []
+        self._collisions = {}
+
+    def _add(self, collider):
+        self._colliders.append(collider)
+
+    def update(self):
+        """Detect and process all collisions."""
+        for pair in self._collisions:
+            colliders_type_1 = [
+                item for item in self._colliders
+                if item.col_type == pair.first]
+            colliders_type_2 = [
+                item for item in self._colliders
+                if item.col_type == pair.second]
+            for collider_1 in colliders_type_1:
+                for collider_2 in colliders_type_2:
+                    collision_rect = self.check_collision(collider_1,
+                                                          collider_2)
+                    if collision_rect:
+                        for callback in self._collisions[pair]:
+                            if callback:
+                                callback(collision_rect)
+
+    @staticmethod
+    def check_collision(col_1, col_2):
+        """Check collisions between two colliders.
+
+        Returns `None` if no collision occured, or returns rectangle of
+        overlapping region between collider maps.
+
+        :param col1: first collider
+        :type col1: :class:`Collider`
+        :param col2: second collider
+        :type col2: :class:`Collider`
+        :rtype: tuple of two :class:`Point`
+        """
+
+        width_1 = max(map(len, col_1.phys_map))
+        height_1 = len(col_1.phys_map)
+        topleft_1 = col_1.pos
+        botright_1 = topleft_1 + Point(width_1, height_1)
+
+        width_2 = max(map(len, col_2.phys_map))
+        height_2 = len(col_2.phys_map)
+        topleft_2 = col_2.pos
+        botright_2 = topleft_2 + Point(width_2, height_2)
+        if (
+                topleft_1.x >= botright_2.x or topleft_1.y >= botright_2.y or
+                botright_1.x <= topleft_2.x or botright_1.y <= topleft_2.y
+        ):
+            # Definelty not overlapping
+            return
+        # Now find where exactopleft_y overlapping occured
+        topleft_overlap = Point(max(topleft_1.x, topleft_2.x),
+                                max(topleft_1.y, topleft_2.y))
+        botright_overlap = Point(min(botright_1.x, botright_2.x),
+                                 min(botright_1.y, botright_2.y))
+        # Now find if they actually collided
+        # first, calculate offsets
+        overlap_1 = Point()
+        overlap_2 = Point()
+        overlap_1.x = abs(topleft_1.x - topleft_overlap.x)
+        overlap_1.y = abs(topleft_1.y - topleft_overlap.y)
+        overlap_2.x = abs(topleft_2.x - topleft_overlap.x)
+        overlap_2.y = abs(topleft_2.y - topleft_overlap.y)
+        # iterate over overlapping region
+        # and search for collision
+        for i in range(botright_overlap.x - topleft_overlap.x):
+            for j in range(botright_overlap.y - topleft_overlap.y):
+                # TODO: check length of current y-level string
+                # it might be not enough to contain i + ox1/2 element
+                if (
+                        col_1.phys_map[j + overlap_1.y][i + overlap_1.x] ==
+                        col_2.phys_map[j + overlap_2.y][i + overlap_2.x] ==
+                        CollisionManager.__solid_matter__
+                ):
+                    return (topleft_overlap, botright_overlap)
+
+    def _add_collision(self, collider, other_classname, callback=None):
+        """Add collision handler.
+
+        Adds handler to be called when collision of colliders of `col_type`
+        `other_classname` and `collider`'s `col_type` occurs.
+
+        :param collider: collider to which type's add handler
+        :type collider: :class:`Collider`
+        :param str other_classname: type name of other collider instances to
+        check collisions with
+        :paran function callback: handler callback. Function that is called
+        whenever collision is detected
+        """
+
+        if collider not in self._colliders:
+            raise ValueError("Attempt to add collision handler for "
+                             "unregistered collider {0}".format(collider))
+        type_pair = TypePair(collider.col_type, other_classname)
+        self._collisions.setdefault(type_pair, []).append(callback)
 
 
-class CollisionDetector(UpdatableSettings):
+class Collider(object):
+    """Collider component class.
 
-    def __init__(self, settings={}):
-        self._settings = settings
+    When added to object, enables it to participate in coliision processing
+    system: i.e. to be able to detect and process collisions between the object
+    and other ones.
 
+    :param str col_type: name of the collider type. Used in processing possible
+    collisions
+    :param list phys_map: list of strings representing collider physical
+    geometry. All strings must be of equal length. Class member __solid_matter__
+    of CollisionManager represents solid geometry, all other chars are treated
+    as void space and may be any.
+    :param pos: left top corner of collider map
+    :type pos: :class:`Point`
+    """
 
-if __name__ == "__main__":
-    from utils import dotdict
+    __manager__ = None
 
-    settings = dotdict({
-        "setting1": True,
-        "setting2": 50,
-        "setting3": "Disabled"
-    })
+    def __init__(self, col_type, phys_map, pos):
+        if Collider.__manager__ is None:
+            raise ValueError("You can't use Collider objects without "
+                             "ColliderManager. Please create it first.")
+        self._mgr = Collider.__manager__()  # manager is weakreaf, thus '()'
+        self._col_type = col_type
+        self._pos = pos
+        self._phys_map = phys_map
+        self._mgr._add(self)
 
-    settings_manager = SettingsManager({"UpdatableSettings": settings.copy()})
-    print(settings_manager._smap)
-    s1 = UpdatableSettings(settings_manager, settings)
-    print(s1._settings)
-    s1.updateInstanceSettings({"Lolo": 5})
-    print(s1._settings)
-    print(settings_manager._smap)
-    s1.notifySettingsManager()
-    print(settings_manager._smap)
+    @property
+    def phys_map(self):
+        return self._phys_map
+
+    @property
+    def col_type(self):
+        return self._col_type
+
+    @property
+    def pos(self):
+        return self._pos
+
+    def add_handler(self, other_type, callback=None):
+        """Install handler for collision with type `other_type`.
+
+        Handler is fired when collision between current collider and any other
+        collider of type `other_type` detected by `update` method of class
+        :class:`CollisionManager`. Callback is `None` by default.
+
+        :param str other_type: type of collider to install collision handler
+        with
+        :param function callback: function which is called when current
+        CollisionManager's update method detects collision of this collider
+        with collider of type `other_type`
+        """
+
+        self._mgr._add_collision(self, other_type, callback)

--- a/xoinvader/ingame.py
+++ b/xoinvader/ingame.py
@@ -9,6 +9,7 @@ from xoinvader.keys import K_A, K_D, K_E, K_F, K_R, K_SPACE, K_ESCAPE, K_Q
 from xoinvader.ship import GenericXEnemy, Playership
 from xoinvader.state import State
 from xoinvader.utils import Point
+from xoinvader.collision import CollisionManager
 from xoinvader.common import Settings
 from xoinvader.curses_utils import Style
 from xoinvader.render import render_objects
@@ -92,6 +93,7 @@ class InGameState(State):
     def __init__(self, owner):
         super(InGameState, self).__init__(owner)
         self._objects = []
+        self._collision_manager = CollisionManager()
         self._screen = self._owner.screen
 
         self.bg = Background(Settings.path.level1bg)
@@ -110,6 +112,12 @@ class InGameState(State):
             Point(x=15, y=3), Settings.layout.field.edge)
 
         self.add(self.enemy)
+
+        self.enemy_2 = GenericXEnemy(
+            Settings.layout.field.edge - Point(20, 4),
+            Settings.layout.field.edge)
+
+        self.add(self.enemy_2)
 
     # TODO: [object-system]
     #  * implement GameObject common class for using in states
@@ -175,6 +183,7 @@ class InGameState(State):
         self._events.handle()
 
     def update(self):
+        self._collision_manager.update()
         for obj in self._objects:
             obj.update()
 

--- a/xoinvader/ship.py
+++ b/xoinvader/ship.py
@@ -5,6 +5,7 @@ from xoinvader.sound import Mixer
 from xoinvader.render import Renderable
 from xoinvader.weapon import Blaster, Laser, UM, EBlaster
 from xoinvader.utils import Point, Surface, InfiniteList
+from xoinvader.collision import Collider
 from xoinvader.common import Settings, get_json_config
 
 
@@ -259,6 +260,11 @@ class GenericXEnemy(Ship):
         self._image = Surface([['x', '^', 'x'],
                                [' ', 'X', ' '],
                                [' ', '*', ' ']])
+        self._collider = Collider(self.__class__.__name__,
+                                  ["###",
+                                   ".#.",
+                                   ".#."],  # benis :DDD
+                                  self._pos)
 
         self.add_weapon(EBlaster())
         self._fire = True
@@ -295,6 +301,16 @@ class Playership(Ship):
         self._pos = Point(
             x=pos.x - self._image.width // 2,
             y=pos.y - self._image.height)
+
+        self._collider = Collider(self.__class__.__name__,
+                                  ["  #  ",
+                                   "#####",
+                                   " # # "],
+                                  self._pos)
+        def enemy_clash(_):
+            self.take_damage(10)
+
+        self._collider.add_handler(GenericXEnemy.__name__, enemy_clash)
         self._border = border
 
         self._fire = False

--- a/xoinvader/tests/test_collision.py
+++ b/xoinvader/tests/test_collision.py
@@ -1,10 +1,147 @@
-import unittest
+import pytest
 
-import xoinvader.collision
+from xoinvader.collision import Collider, CollisionManager, TypePair
+from xoinvader.utils import Point
 
 
-class TestCollision(unittest.TestCase):
-    unittest.skip("Stub.")
+def test_collision():
+    with pytest.raises(ValueError):
+        c = Collider("", [], None)
+    cm = CollisionManager()
+    c1 = Collider(
+        "",
+        [
+            "##",
+            "##",
+        ],
+        Point(0, 0))
 
-    def test_collision(self):
-        pass
+    c2 = Collider(
+        "",
+        [
+            "..",
+            ".."
+        ],
+        Point(0, 0))
+
+    assert cm.check_collision(c1, c2) is None
+
+    c3 = Collider(
+        "",
+        [
+            "##",
+            "##"
+        ],
+        Point(0, 0))
+    assert cm.check_collision(c1, c3)
+
+    c3._pos = Point(1, 0)
+    assert cm.check_collision(c1, c3)
+    c3._pos = Point(0, 1)
+    assert cm.check_collision(c1, c3)
+    c3._pos = Point(1, 1)
+    assert cm.check_collision(c1, c3)
+
+    c3._pos = Point(0, 2)
+    assert cm.check_collision(c1, c3) is None
+    c3._pos = Point(2, 0)
+    assert cm.check_collision(c1, c3) is None
+
+    c4 = Collider(
+        "",
+        [
+            "..",
+            ".#",
+        ],
+        Point(0, 0))
+
+    assert cm.check_collision(c1, c4)
+    c4._pos = Point(1, 0)
+    assert cm.check_collision(c1, c4) is None
+
+
+def test_type_pair():
+    p1 = TypePair("t1", "t2")
+    p2 = TypePair("t2", "t1")
+    assert p1._pair == p2._pair
+    assert p1 == p2
+    assert hash(p1) == hash(p2)
+
+
+def test_collision_manager():
+    import gc
+    gc.collect()
+    assert Collider.__manager__ is None
+
+    class MockManager(object):
+        def __call__(self):
+            return self
+
+        def _add(self, _collider):
+            pass
+
+    m = MockManager()
+    Collider.__manager__ = m
+    c = Collider("", [], None)
+    mm = CollisionManager()
+    with pytest.raises(ValueError):
+        mm._add_collision(c, "other", lambda: _)
+    assert not mm._colliders
+    assert not mm._collisions
+
+    Collider.__manager__ = None
+    mm = CollisionManager()
+
+    c1 = Collider("t1", [], None)
+    c2 = Collider("t2", [], None)
+    mm._add_collision(c1, "t1", lambda: _)
+    assert len(mm._collisions) == 1
+    mm._add_collision(c2, "t2", lambda: _)
+    assert len(mm._collisions) == 2
+    mm._add_collision(c2, "t1", lambda: _)
+    assert len(mm._collisions) == 3
+    c2.add_handler("t1", lambda: _)
+    t = TypePair("t1", "t2")
+    assert len(mm._collisions) == 3
+    assert len(mm._collisions[t]) == 2
+
+def test_manager_update():
+    Collider.__manager__ = None
+    mm = CollisionManager()
+
+    class Ship(object):
+        def __init__(self):
+            self.health = 10
+            self.pos = Point(0, 10)
+            self.collider = Collider("ship",
+                                     ["..#..",
+                                      "#####",
+                                      ".#.#."],
+                                     Point(0, 10))
+
+        def rocket_collision(self):
+            def callback(_):
+                self.health -= 10
+            return callback
+
+    ship = Ship()
+
+    r_pos = Point(0, 0)
+    rocket = Collider("rocket",
+                      ["#",
+                       "#",
+                       "#"],
+                      r_pos)
+
+    ship.collider.add_handler("rocket", ship.rocket_collision())
+
+    mm.update()
+    assert ship.health == 10
+
+    r_pos.y = 8
+    mm.update()
+    assert ship.health == 10
+
+    r_pos.y = 9
+    mm.update()
+    assert ship.health == 0


### PR DESCRIPTION
**Closes issue(s):** [ #19 ]

**Description of the changes:**
**add collision module and tests**

Collision module consists from 2 classes: CollisionManager and
Collider. There's also one ancillary class: TypePair.

To enjoy the might of collision detection and processing system, you
must first create the CollisionManager instance, and then create some
Colliders and install handlers for them for each other types. Handlers
are commutative, i.e. if you installed handler for collider of "ship"
type to handle "rocket" type collisions, it means that you don't have
to install collider with "ship" to each new rocket object yoy have
created.

**add colliders for GenericXEnemy and Playership**

Just two colliders, preliminary step to add sample collision
processing to InGame state. We can't check for collision with bullets
yet, due to some circumstances, but we can do it for two ships.

**add CollisionManager instance to InGameState**

We add CollisionManager and then add second enemy on the y-level of
player ship, to be able to collide with it.

As for now, for some reason, it's impossible, since player controlled
ship just wraps to the left of the field. When we have it fixed,
collision processing should automatically start working.

**Reviewers:** [ @pkulev ]

**Task list:**

- [x] submit pull request
- [x] review
- [x] testing
- [x] fixes after review, squashing, rebasing to master
