### PR TITLE
implement Level support for xoinvader game

### DIFF
--- a/xoinvader/ingame.py
+++ b/xoinvader/ingame.py
@@ -5,17 +5,17 @@ import curses
 import logging
 
 from xoinvader.background import Background
-from xoinvader.gui import TextWidget, WeaponWidget, Bar
-from xoinvader.keys import K_A, K_D, K_E, K_F, K_R, K_SPACE, K_ESCAPE, K_Q
-from xoinvader.ship import GenericXEnemy, Playership
-from xoinvader.state import State
-from xoinvader.utils import Point
 from xoinvader.collision import CollisionManager
 from xoinvader.common import Settings
 from xoinvader.curses_utils import Style
+from xoinvader.gui import TextWidget, WeaponWidget, Bar
+from xoinvader.handlers import Handler
+from xoinvader.keys import K_A, K_D, K_E, K_F, K_R, K_SPACE, K_ESCAPE, K_Q
 from xoinvader.level import Level
 from xoinvader.render import render_objects
-from xoinvader.handlers import Handler
+from xoinvader.ship import GenericXEnemy, Playership
+from xoinvader.state import State
+from xoinvader.utils import Point
 
 
 LOG = logging.getLogger(__name__)

--- a/xoinvader/level.py
+++ b/xoinvader/level.py
@@ -1,17 +1,18 @@
-"""Module for creating and maintaining waves of incoming enemies."""
+"""Module for creating and maintaining xoinvader levels."""
 
-class EnemyWave(object):
-    """Container for enemy wave behavior.
+
+class Level(object):
+    """Container for level event sequence and resources.
 
     Intended to use as just container, but may be subclassed. It's useful in
-    order to add methods for creating concrete animations and spawning actual
-    enemies.
+    order to add methods for creating concrete animations and events, such as
+    spawning actual enemies, bonuses, initiating boss fights and so on.
 
     :param int speed: relative speed of the wave. Means how fast time advances.
-    The faster time advances, the shorter the delays between enemy spawns.
-    :param dict events: map from relative time in event to function that spawns
-    the enemies.
-    :param bool running: if wave currently advances.
+    The faster time advances, the shorter the delays between events triggering.
+    :param dict events: map from relative time in event to event starting
+    function.
+    :param bool running: if event sequence currently advances.
     """
 
     def __init__(self, speed=0):
@@ -34,16 +35,16 @@ class EnemyWave(object):
         return self._running
 
     def add_event(self, time, callback):
-        """Add spawning event to some point in time.
+        """Add event to some point in time.
 
-        :param int time: point in time relative to wave start when to run
+        :param int time: point in time relative to level start when to run
         `callback`. Callback is fired when `_counter` exceeds provided value
         :param function callback: callback to be runned when wave reaches `time`
         """
         self._events.setdefault(time, []).append(callback)
 
     def start(self):
-        """Start the enemy wave.
+        """Start the level.
 
         Resets the counter, recomputes the list of event timeouts and sets the
         `running` property to `True`.
@@ -56,8 +57,8 @@ class EnemyWave(object):
     def update(self):
         """Update the counter and fire appropriate events.
 
-        Function is doing anything useful only when the EnemyWave has been
-        started earlier, i.e. currently in running state.
+        Function is doing anything useful only when the Level has been started
+        earlier, i.e. currently in running state.
         Function updates current timer and fires all events, which timeouts have
         expired. If there's no more events in the queue, the running state
         terminates and object goes to sleep.

--- a/xoinvader/tests/test_level.py
+++ b/xoinvader/tests/test_level.py
@@ -1,10 +1,10 @@
 import pytest
 
-from xoinvader.enemy_wave import EnemyWave
+from xoinvader.level import Level
 
 
 def test_wave():
-    e = EnemyWave()
+    e = Level()
 
     class MockObject(object):
         def __init__(self):


### PR DESCRIPTION
Well, actually it's just renaming `EnemyWave` to `Level`, since `EnemyWave`
turned out to be just that type of sequence handler that makes it fit
for xoinvader level support.

Also this commit moves all game objects in TestLevel class in InGame
state, as they all are part of the level, not the state. This division
came quite natural, which is good. Now we can proceed to move test
level to separate module and to create something more elaborate, with
more enemies and backgrounds, and expiriment with level utils, like
enemy ships cleanup and so on.

Tests and imports were altered according to name changes. No logic
changes in the engine were implemented.

issue #22

**Closes issue(s):** [ #22 ]

**Description of the changes:**

  * What's new: Level-related objects moved to `TestLevel` class in `InGame` state.
  * Refactoring: `EnemyWave` renamed to `Level`, as it actually was it from the beginning.

**Reviewers:** [ @pkulev ]

**Task list:**

- [x] submit pull request
- [ ] review
- [ ] testing
- [ ] fixes after review, squashing, rebasing to master
