### PR TITLE
Implement game objects removal, move out charge logic from weapons

### DIFF
--- a/xoinvader/application/__init__.py
+++ b/xoinvader/application/__init__.py
@@ -6,6 +6,30 @@ from xoinvader.constants import DEFAULT_FPS, DRIVER_NCURSES, DRIVER_SDL
 from xoinvader.common import Settings
 
 
+_CURRENT_APPLICATION = None
+"""Current application instance."""
+
+
+class ApplicationNotInitializedError(Exception):
+    """Raise when try to get not initialized application."""
+
+    def __init__(self):
+        super(ApplicationNotInitializedError, self).__init__(
+            "Application not initialized.")
+
+
+def get_current():
+    """Current application getter.
+
+    :return: current application object
+    """
+
+    if _CURRENT_APPLICATION is not None:
+        return _CURRENT_APPLICATION
+    else:
+        raise ApplicationNotInitializedError()
+
+
 # TODO: implement proper choosing by env
 def get_application():
     """Application class getter.
@@ -50,6 +74,9 @@ class Application(object):
     """
 
     def __init__(self):
+        global _CURRENT_APPLICATION
+        _CURRENT_APPLICATION = self
+
         self._state = None
         self._states = {}
         self._screen = None

--- a/xoinvader/application/__init__.py
+++ b/xoinvader/application/__init__.py
@@ -75,7 +75,7 @@ class Application(object):
         :type: str
         """
         if self._state:
-            return self._state.__class__.__name__
+            return self._state
         else:
             raise AttributeError("There is no available state.")
 

--- a/xoinvader/charge.py
+++ b/xoinvader/charge.py
@@ -36,12 +36,24 @@ class WeaponCharge(Renderable):
         self._dx = dx
         self._dy = dy
 
+        # Set to True means that object in destroying phase
+        # and will ignore remove_obsolete signal
+        self._destroy = False
+
     def get_render_data(self):
         return ([self._pos], self._image.get_image())
 
     def remove_obsolete(self, pos):
-        LOG.debug("%s remove obsolete.", self._type)
-        application.get_current().state.remove(self)
+        border = Settings.layout.field.border
+        pos = self._pos[int]
+        if (
+                pos.x > self._image.width + border.x or
+                pos.x + self._image.width < 0 or
+                int(pos.y) > self._image.height + border.y or
+                int(pos.y) + self._image.height < 0
+        ) and not self._destroy:
+            application.get_current().state.remove(self)
+            self._destroy = True
 
     def update(self):
         """Update coords."""

--- a/xoinvader/charge.py
+++ b/xoinvader/charge.py
@@ -1,0 +1,109 @@
+"""Game weapon charge classes."""
+
+
+import logging
+import curses
+
+from xoinvader import application
+from xoinvader.common import Settings, get_json_config
+from xoinvader.render import Renderable
+from xoinvader.utils import Point, Surface
+
+
+CONFIG = get_json_config(Settings.path.config.charges)
+LOG = logging.getLogger(__name__)
+
+
+# pylint: disable=too-many-arguments
+class WeaponCharge(Renderable):
+    """Weapon charge representation.
+
+    Separate renderable object that updates and renders as others
+    in main loop. Must register/deregister itself via state's
+    add/remove methods.
+    """
+
+    def __init__(self, pos, image, damage=0, radius=0, dx=0, dy=0):
+        self._pos = pos
+        self._image = image
+        self._type = self.__class__.__name__
+        application.get_current().state.add(self)
+
+        self._damage = damage
+        self._radius = radius
+        # TODO: [object-movement]
+        # Generalize update to support dx
+        self._dx = dx
+        self._dy = dy
+
+    def get_render_data(self):
+        return ([self._pos], self._image.get_image())
+
+    def remove_obsolete(self, pos):
+        LOG.debug("%s remove obsolete.", self._type)
+        application.get_current().state.remove(self)
+
+    def update(self):
+        """Update coords."""
+
+        self._pos += Point(self._dx, self._dy)
+
+
+# TODO: Implement hitscan behaviour
+# pylint: disable=useless-super-delegation
+class Hitscan(WeaponCharge):
+    """Hitscan weapon charge hits target immediately.
+
+    Can pierce enemies?
+    """
+
+    def __init__(self, pos, image, **kwargs):
+        super(Hitscan, self).__init__(pos, image, **kwargs)
+
+
+class Projectile(WeaponCharge):
+    """Projectile weapon has generic physics of movement."""
+
+    def __init__(self, pos, image, **kwargs):
+        super(Projectile, self).__init__(pos, image, **kwargs)
+
+
+# TODO: write template documentation for charges and weapons
+class BasicPlasmaCannon(Projectile):
+    """Small damage, no radius."""
+
+    def __init__(self, pos):
+        super(BasicPlasmaCannon, self).__init__(
+            pos, Surface(["^"], style=[[curses.A_BOLD]]),
+            **CONFIG[self.__class__.__name__])
+
+
+class EBasicPlasmaCannon(Projectile):
+    """Enemy plasma cannon."""
+
+    def __init__(self, pos):
+        super(EBasicPlasmaCannon, self).__init__(
+            pos, Surface([":"], style=[[curses.A_BOLD]]),
+            **CONFIG[self.__class__.__name__])
+
+
+class BasicLaserCharge(Projectile):
+    """Laser. Quite fast but cannot pierce enemies."""
+
+    def __init__(self, pos):
+        super(BasicLaserCharge, self).__init__(
+            pos, Surface(["|"], style=[[curses.A_BOLD]]),
+            **CONFIG[self.__class__.__name__])
+
+
+class BasicUnguidedMissile(Projectile):
+    """Unguided missile with medium damage and small radius."""
+
+    def __init__(self, pos):
+        super(BasicUnguidedMissile, self).__init__(
+            pos, Surface([
+                "^",
+                "|",
+                "*"
+            ], style=[[curses.A_BOLD] for _ in range(3)]),
+            **CONFIG[self.__class__.__name__])

--- a/xoinvader/collision.py
+++ b/xoinvader/collision.py
@@ -78,6 +78,7 @@ class CollisionManager(object):
         """Add collider."""
         self._colliders.append(collider)
 
+    # pylint: disable=too-many-nested-blocks
     def update(self):
         """Detect and process all collisions."""
 

--- a/xoinvader/common.py
+++ b/xoinvader/common.py
@@ -9,14 +9,27 @@ from xoinvader.utils import dotdict, Point
 
 
 def get_json_config(path):
-    """Return Settings object made from json."""
+    """Return Settings object made from json.
+
+    :param str path: path to config
+
+    :return xoinvader.utils.dotdict: parsed config
+    """
+
     with open(path) as fd:
         config = dotdict(json.load(fd))
     return config
 
 
 def rootify(root, config):
-    "Append paths in dict to root."
+    """Append paths in dict to root.
+
+    :param str root: common root
+    :param dict config:
+
+    :return dict: rootified config
+    """
+
     for key, path in config.items():
         if isinstance(path, dict):
             rootify(root, path)
@@ -71,6 +84,7 @@ def update_system_settings(args):
 
     :param dict args: arguments
     """
+
     for arg, val in args.items():
         if arg in Settings.system:
             Settings.system[arg] = val

--- a/xoinvader/config/charges.json
+++ b/xoinvader/config/charges.json
@@ -1,0 +1,22 @@
+{
+    "BasicPlasmaCannon": {
+        "damage": 1,
+        "radius": 0,
+        "dy": -1
+    },
+    "EBasicPlasmaCannon": {
+        "damage": 25,
+        "radius": 1,
+        "dy": 1
+    },
+    "BasicLaserCharge": {
+        "damage": 2,
+        "radius": 0,
+        "dy": -2
+    },
+    "BasicUnguidedMissile": {
+        "damage": 3,
+        "radius": 3,
+        "dy": -1
+    }
+}

--- a/xoinvader/config/path.json
+++ b/xoinvader/config/path.json
@@ -1,25 +1,25 @@
 {
-    "config" : {
-        "ships" : "/config/ships.json",
-        "weapons" : "/config/weapons.json"
+    "config": {
+        "ships": "/config/ships.json",
+        "weapons": "/config/weapons.json"
     },
-    "sound" : {
-        "weapon" : {
-            "Blaster" : "/res/snd/basic_blaster.ogg",
-            "Laser" : "/res/snd/basic_laser.ogg",
-            "EBlaster" : "/res/snd/basic_eblaster.ogg",
-            "UM" : "/res/snd/basic_um.ogg"
+    "sound": {
+        "weapon": {
+            "Blaster": "/res/snd/basic_blaster.ogg",
+            "Laser": "/res/snd/basic_laser.ogg",
+            "EBlaster": "/res/snd/basic_eblaster.ogg",
+            "UM": "/res/snd/basic_um.ogg"
         },
-        "ship" : {
-            "Playership" : {
-                "engine" : "/res/snd/playership_engine.ogg"
+        "ship": {
+            "Playership": {
+                "engine": "/res/snd/playership_engine.ogg"
             }
         }
     },
-    "image" : {
-        "ship" : {
-            "TestShip" : "/res/gfx/ship.png"
+    "image": {
+        "ship": {
+            "TestShip": "/res/gfx/ship.png"
         }
     },
-    "level1bg" : "/res/level1.bg"
+    "level1bg": "/res/level1.bg"
 }

--- a/xoinvader/config/path.json
+++ b/xoinvader/config/path.json
@@ -1,5 +1,6 @@
 {
     "config": {
+        "charges": "/config/charges.json",
         "ships": "/config/ships.json",
         "weapons": "/config/weapons.json"
     },

--- a/xoinvader/config/ships.json
+++ b/xoinvader/config/ships.json
@@ -1,25 +1,24 @@
 {
-	"Playership" : {
-		"dx" : 1,
-		"hull" : 100,
-		"shield" : 100,
-		"max_hull" : 100,
-		"max_shield" : 100
-	},
-
-	"GenericXEnemy" : {
-		"dx" : 2,
-		"hull" : 100,
-		"shield" : 100,
-		"max_hull" : 100,
-		"max_shield" : 100
-	},
-    "TestShip" : {
-        "dx" : 10,
-        "dy" : 2,
-        "hull" : 100,
-        "shield" : 100,
-        "max_hull" : 100,
-        "max_shield" : 100
+    "Playership": {
+        "dx": 1,
+        "hull": 100,
+        "shield": 100,
+        "max_hull": 100,
+        "max_shield": 100
+    },
+    "GenericXEnemy": {
+        "dx": 2,
+        "hull": 100,
+        "shield": 100,
+        "max_hull": 100,
+        "max_shield": 100
+    },
+    "TestShip": {
+        "dx": 10,
+        "dy": 2,
+        "hull": 100,
+        "shield": 100,
+        "max_hull": 100,
+        "max_shield": 100
     }
 }

--- a/xoinvader/config/weapons.json
+++ b/xoinvader/config/weapons.json
@@ -2,33 +2,21 @@
     "Blaster": {
         "ammo": "infinite",
         "max_ammo": "infinite",
-        "cooldown": 0.2,
-        "damage": 1,
-        "radius": 0,
-        "dy": 1
+        "cooldown": 0.2
     },
     "Laser": {
         "ammo": 50,
         "max_ammo": 50,
-        "cooldown": 1,
-        "damage": 2,
-        "radius": 0,
-        "dy": 2
+        "cooldown": 1
     },
     "UM": {
         "ammo": 15,
         "max_ammo": 15,
-        "cooldown": 2,
-        "damage": 3,
-        "radius": 1,
-        "dy": 1
+        "cooldown": 2
     },
     "EBlaster": {
         "ammo": "infinite",
         "max_ammo": "infinite",
-        "cooldown": 0.7,
-        "damage": 25,
-        "radius": 1,
-        "dy": -1
+        "cooldown": 0.7
     }
 }

--- a/xoinvader/config/weapons.json
+++ b/xoinvader/config/weapons.json
@@ -1,37 +1,34 @@
 {
-	"Blaster" : {
-		"ammo" : "infinite",
-		"max_ammo" : "infinite",
-		"cooldown" : 0.2,
-		"damage" : 1,
-		"radius" : 0,
-		"dy" : 1
-	},
-	
-	"Laser" : {
-		"ammo" : 50,
-		"max_ammo" : 50,
-		"cooldown" : 1,
-		"damage" : 2,
-		"radius" : 0,
-		"dy" : 2
-	},
-
-	"UM" : {
-		"ammo" : 15,
-		"max_ammo" : 15,
-		"cooldown" : 2,
-		"damage" : 3,
-		"radius" : 1,
-		"dy" : 1
-	},
-
-	"EBlaster" : {
-		"ammo" : "infinite",
-		"max_ammo" : "infinite",
-		"cooldown" : 0.7,
-		"damage" : 25,
-		"radius" : 1,
-		"dy" : -1
-	}
+    "Blaster": {
+        "ammo": "infinite",
+        "max_ammo": "infinite",
+        "cooldown": 0.2,
+        "damage": 1,
+        "radius": 0,
+        "dy": 1
+    },
+    "Laser": {
+        "ammo": 50,
+        "max_ammo": 50,
+        "cooldown": 1,
+        "damage": 2,
+        "radius": 0,
+        "dy": 2
+    },
+    "UM": {
+        "ammo": 15,
+        "max_ammo": 15,
+        "cooldown": 2,
+        "damage": 3,
+        "radius": 1,
+        "dy": 1
+    },
+    "EBlaster": {
+        "ammo": "infinite",
+        "max_ammo": "infinite",
+        "cooldown": 0.7,
+        "damage": 25,
+        "radius": 1,
+        "dy": -1
+    }
 }

--- a/xoinvader/gui.py
+++ b/xoinvader/gui.py
@@ -163,11 +163,11 @@ class PopUpNotificationWidget(TextWidget):
     """
 
     def __init__(self, pos, text, style=None, timeout=1.0, callback=None):
-        super(self.__class__, self).__init__(pos, text, style)
+        super(PopUpNotificationWidget, self).__init__(pos, text, style)
 
         self._callback = callback
         self._timer = Timer(timeout, self._finalize_cb)
-        self._update_text = super(self.__class__, self).update
+        self._update_text = super(PopUpNotificationWidget, self).update
         self._timer.start()
 
     def _finalize_cb(self):

--- a/xoinvader/gui.py
+++ b/xoinvader/gui.py
@@ -24,6 +24,7 @@ class TextWidget(Renderable):
     """
 
     render_priority = 1
+    draw_on_border = True
 
     def __init__(self, pos, text, style=None):
         self._pos = pos
@@ -194,6 +195,7 @@ class WeaponWidget(Renderable):
     """
 
     render_priority = 1
+    draw_on_border = True
 
     def __init__(self, pos, get_data):
         self._pos = pos
@@ -245,6 +247,7 @@ class Bar(Renderable):
     """
 
     render_priority = 1
+    draw_on_border = True
 
     def __init__(
             self, pos,

--- a/xoinvader/ingame.py
+++ b/xoinvader/ingame.py
@@ -212,6 +212,20 @@ class InGameState(State):
         except AttributeError:
             pass
 
+    def remove(self, obj):
+        """Remove GameObject from State's list of objects.
+
+        Removed objects should be collected by GC.
+
+        :param object obj: GameObject
+        """
+
+        LOG.debug("%s", obj)
+        try:
+            self._objects.remove(obj)
+        except ValueError:
+            LOG.exception("Object %s is not in State's object list.", obj)
+
     def _create_gui(self):
         """Create user interface."""
 

--- a/xoinvader/ingame.py
+++ b/xoinvader/ingame.py
@@ -206,14 +206,11 @@ class InGameState(State):
 
         # TODO: Because we don't have common GameObject interface
         # This is temporary smellcode
-        try:
-            for item in obj:
-                if item.compound:
-                    subitems = item.get_renderable_objects()
-                    LOG.debug("Subitems: %s", subitems)
-                    self._objects.extend(subitems)
-        except AttributeError:
-            pass
+        for item in obj:
+            if item.compound:
+                subitems = item.get_renderable_objects()
+                LOG.debug("Subitems: %s", subitems)
+                self._objects.extend(subitems)
 
     def remove(self, obj):
         """Remove GameObject from State's list of objects.

--- a/xoinvader/ingame.py
+++ b/xoinvader/ingame.py
@@ -202,13 +202,16 @@ class InGameState(State):
 
         obj = obj if isinstance(obj, (list, tuple)) else [obj]
         self._objects.extend(obj)
+        LOG.debug("%s", obj)
 
         # TODO: Because we don't have common GameObject interface
         # This is temporary smellcode
         try:
             for item in obj:
                 if item.compound:
-                    self._objects.extend(item.get_renderable_objects())
+                    subitems = item.get_renderable_objects()
+                    LOG.debug("Subitems: %s", subitems)
+                    self._objects.extend(subitems)
         except AttributeError:
             pass
 

--- a/xoinvader/ingame.py
+++ b/xoinvader/ingame.py
@@ -3,6 +3,7 @@
 import curses
 import logging
 
+from xoinvader import application
 from xoinvader.background import Background
 from xoinvader.collision import CollisionManager
 from xoinvader.common import Settings
@@ -104,9 +105,11 @@ class TestLevel(Level):
         self._player_ship = Playership(
             Settings.layout.field.player, Settings.layout.field.edge)
         self._state_add(self._player_ship)
+        self._enemies = []
 
         self.add_event(1, self.spawn4)
         self.add_event(100, lambda: None)
+        self.add_event(200, self.del4)
 
         self.bg = Background(Settings.path.level1bg, speed=10, loop=True)
         self.bg.start(True)
@@ -159,10 +162,12 @@ class TestLevel(Level):
             "", e4, "_pos",
             self.get_keyframes(1, right_side - 20, -1), interp=True)
 
-        self._state_add(e1)
-        self._state_add(e2)
-        self._state_add(e3)
-        self._state_add(e4)
+        self._enemies = [e1, e2, e3, e4]
+        self._state_add(self._enemies)
+
+    def del4(self):
+        for enemy in self._enemies:
+            application.get_current().state.remove(enemy)
 
 
 class InGameState(State):

--- a/xoinvader/ingame.py
+++ b/xoinvader/ingame.py
@@ -224,10 +224,17 @@ class InGameState(State):
         """
 
         LOG.debug("%s", obj)
+
         try:
+            if obj.compound:
+                for subobj in obj.get_renderable_objects():
+                    self._objects.remove(subobj)
+                    del subobj
             self._objects.remove(obj)
         except ValueError:
             LOG.exception("Object %s is not in State's object list.", obj)
+        finally:
+            del obj
 
     def _create_gui(self):
         """Create user interface."""

--- a/xoinvader/render.py
+++ b/xoinvader/render.py
@@ -15,12 +15,15 @@ class Renderable(object):
 
     .. class-variables::
 
+    * compound (bool): if object consists of other renderables
+
     * render_priority (int): priority for renderer, greater -> rendered later
 
     * draw_on_border (bool): allow or not drawing on border
     if not allowed - renderer will send remove_obsolete signal to object
     """
 
+    compound = False
     render_priority = 0
     draw_on_border = False
 

--- a/xoinvader/sound.py
+++ b/xoinvader/sound.py
@@ -59,13 +59,20 @@ class PygameMixer(object, metaclass=Singleton):
 
         self.pygame.mixer.init()
 
-        self._sounds = dict()
+        self._sounds = {}
         self._mute = Settings.system.no_sound
 
     def register(self, object_id, sound_path):
-        """Map object classname to sound object."""
+        """Map object classname to sound object.
+
+        :param str object_id: now this is class name
+        :param str sound_path: path to object's sound
+        """
 
         LOG.debug("Registering %s, %s.", object_id, sound_path)
+        if object_id in self._sounds:
+            return
+
         sound = self.pygame.mixer.Sound(sound_path)
         self._sounds.update({object_id: sound})
 

--- a/xoinvader/tests/test_application.py
+++ b/xoinvader/tests/test_application.py
@@ -24,7 +24,7 @@ def test_application():
     # One element
     app.register_state(StateMock)
     assert len(app._states) == 1  # pylint: disable=protected-access
-    assert app.state == StateMock.__name__
+    assert isinstance(app.state, StateMock)
 
     assert pytest.raises(KeyError, lambda: setattr(app, "state", "test"))
 
@@ -32,10 +32,10 @@ def test_application():
     app.register_state(AnotherStateMock)
     assert len(app.states) == 2
     # Ensure that Application._state hasn't changed
-    assert app.state == StateMock.__name__
+    assert isinstance(app.state, StateMock)
 
     app.state = AnotherStateMock.__name__
-    assert app.state == AnotherStateMock.__name__
+    assert isinstance(app.state, AnotherStateMock)
 
 
 def test_curses_application(monkeypatch):

--- a/xoinvader/tests/test_application.py
+++ b/xoinvader/tests/test_application.py
@@ -5,7 +5,9 @@ import pytest
 from xoinvader import constants
 from xoinvader.common import Settings
 import xoinvader.curses_utils
-from xoinvader.application import get_application, Application
+from xoinvader.application import (
+    get_application, get_current, Application, ApplicationNotInitializedError
+)
 from xoinvader.application.ncurses_app import CursesApplication
 
 from xoinvader.tests.common import StateMock, AnotherStateMock
@@ -14,7 +16,11 @@ from xoinvader.tests.common import StateMock, AnotherStateMock
 def test_application():
     """xoinvader.application.Application"""
 
+    with pytest.raises(ApplicationNotInitializedError):
+        get_current()
+
     app = Application()
+    assert isinstance(get_current(), Application)
     assert pytest.raises(AttributeError, lambda: app.state)
     assert pytest.raises(AttributeError, app.start)
     assert app.screen is None
@@ -40,6 +46,7 @@ def test_application():
 
 def test_curses_application(monkeypatch):
     """xoinvader.application.CursesApplication"""
+
     monkeypatch.setattr(
         xoinvader.curses_utils, "create_window",
         lambda *args, **kwargs: True)
@@ -49,6 +56,7 @@ def test_curses_application(monkeypatch):
 
     assert CursesApplication == get_application()
     app = CursesApplication()
+    assert isinstance(get_current(), CursesApplication)
 
     assert app.set_caption("test") is None
     assert _test_application_loop(app)
@@ -73,6 +81,7 @@ def test_pygame_application(monkeypatch):
     assert PygameApplication == get_application()
     app = PygameApplication((800, 600), 0, 32)
     app.set_caption("test")
+    assert isinstance(get_current(), PygameApplication)
     assert app.screen is not None
     assert pytest.raises(ValueError, lambda: setattr(app, "fps", "thirty"))
     assert pytest.raises(AttributeError, lambda: app.state)

--- a/xoinvader/tests/test_state.py
+++ b/xoinvader/tests/test_state.py
@@ -1,22 +1,23 @@
 """Tests for xoinvader.state module."""
 
 
-import unittest
+import pytest
 
 from xoinvader.state import State
 
 
-class TestState(unittest.TestCase):
-    """xoinvader.state.State"""
+def test_state():
+    """Test xoinvader.state.State base class."""
 
-    def test_base_class(self):
-        """base_class"""
-        state = State("owner")
+    state = State("owner")
 
-        self.assertEqual(state.owner, "owner")
-        self.assertEqual(state.actor, None)
-        self.assertEqual(state.screen, None)
+    assert state.owner == "owner"
+    assert state.actor is None
+    assert state.screen is None
 
-        self.assertRaises(NotImplementedError, state.events)
-        self.assertRaises(NotImplementedError, state.update)
-        self.assertRaises(NotImplementedError, state.render)
+    with pytest.raises(NotImplementedError):
+        state.events()
+    with pytest.raises(NotImplementedError):
+        state.update()
+    with pytest.raises(NotImplementedError):
+        state.render()

--- a/xoinvader/tests/test_weapon.py
+++ b/xoinvader/tests/test_weapon.py
@@ -13,4 +13,4 @@ def test_weapon(monkeypatch):
     monkeypatch.setattr(weapon, "Mixer", xoinvader.sound.get_mixer)
 
     # pytest.raises(KeyError, lambda:
-    weapon.Weapon(ammo=10, max_ammo=10, cooldown=0.5, damage=1, radius=1, dy=1)
+    weapon.Weapon(ammo=10, max_ammo=10, cooldown=0.5)

--- a/xoinvader/utils.py
+++ b/xoinvader/utils.py
@@ -39,6 +39,7 @@ def setup_logger(name, debug=False, msgfmt=None, timefmt=None):
     """
 
     logger = logging.getLogger(name)
+    logger.propagate = False
     level = logging.DEBUG if debug else logging.INFO
     logger.setLevel(level)
     handler = logging.FileHandler("{0}.log".format(name))

--- a/xoinvader/utils.py
+++ b/xoinvader/utils.py
@@ -167,6 +167,19 @@ class Point(object):
 
         return self.x == other.x and self.y == other.y and self.z == other.z
 
+    def __getitem__(self, cons):
+        """Cast Point to selected type.
+
+        :param type cons: type to cast to
+
+        :return Point: with casted members
+        """
+
+        return Point(
+            x=cons(self.x),
+            y=cons(self.y),
+            z=cons(self.z))
+
 
 class Surface(object):
     """Representation of graphic objects.


### PR DESCRIPTION
**Closes issue(s):** [ #59 ]
**Related to issue(s):** [ #52 ]

**Description of the changes:**

This PR makes two major changes:
* Split Weapon into Weapon and Charge (as separate renderable entities)
* Implement game objects removal

Both of them lead us to adding GAMEPLAY! Pew-pew and homebrew gameovers can be implemented as well as exposions. This is really great good news.

  * What's new:
    * weapon and charge are separate entities
    * remove objects via State's remove method (now it's only InGame state, but will be moved soon)
    * current Application accessible via application.get_current()
  * Fixes:
    * fix logging to stdout
    * fix formatting, docstrings

  * Refactoring:
    * refactor weapon
