### PR TITLE
Use six to add metaclass

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,6 +5,7 @@ pytest
 pylint
 pytest-coverage
 pytest-pylint
+six
 sphinx
 tornado
 tox

--- a/xoinvader/curses_utils.py
+++ b/xoinvader/curses_utils.py
@@ -3,12 +3,15 @@
 import time
 import curses
 
+from six import add_metaclass
+
 from xoinvader.common import Settings
 from xoinvader.utils import Singleton
 
 
 # pylint: disable=too-few-public-methods
-class _Color(object, metaclass=Singleton):
+@add_metaclass(Singleton)
+class _Color(object):
     """Curses color mapping."""
 
     def __init__(self):
@@ -50,7 +53,8 @@ Color = _Color()  # pylint: disable=invalid-name
 
 
 # TODO: rewrite this shit
-class Style(object, metaclass=Singleton):
+@add_metaclass(Singleton)
+class Style(object):
     """Container for style mappings."""
 
     def __init__(self):

--- a/xoinvader/render.py
+++ b/xoinvader/render.py
@@ -1,7 +1,10 @@
 """Rendering routines."""
 
 
+from abc import ABCMeta, abstractmethod
 from operator import attrgetter
+
+from six import add_metaclass
 
 from xoinvader.utils import Point
 
@@ -10,6 +13,7 @@ INVISIBLE_SYMBOLS = " "
 """Symbols that renderer must not render on the screen."""
 
 
+@add_metaclass(ABCMeta)
 class Renderable(object):
     """Base for renderable objects.
 
@@ -27,6 +31,7 @@ class Renderable(object):
     render_priority = 0
     draw_on_border = False
 
+    @abstractmethod
     def get_render_data(self):
         """Renderable.get_render_data(None) -> (gpos_list, data_gen)
 
@@ -37,7 +42,7 @@ class Renderable(object):
             * data_gen: generator which yields tuple (lpos, image, style)
             Example: (Point(x=5, y=5), "*", curses.A_BOLD)
         """
-        raise NotImplementedError
+        pass
 
     def remove_obsolete(self, pos):
         """Renderable.remove_obsolete(Point(int, int)) -> None

--- a/xoinvader/sound.py
+++ b/xoinvader/sound.py
@@ -2,6 +2,8 @@
 
 import logging
 
+from six import add_metaclass
+
 from xoinvader.common import Settings
 from xoinvader.utils import Singleton
 
@@ -48,7 +50,8 @@ class DummyMixer(object):
         LOG.debug("Unmuting.")
 
 
-class PygameMixer(object, metaclass=Singleton):
+@add_metaclass(Singleton)
+class PygameMixer(object):
     """Handle sound files."""
 
     def __init__(self):


### PR DESCRIPTION
Improve python2/3 compatibility.

Signed-off-by: Pavel Kulyov <kulyov.pavel@gmail.com>

**Closes issue(s):** [ # ]

**Description of the changes:**

  * What's new:

  * Fixes:

  * Refactoring:
      use six for adding metaclass
