### PR TITLE
infra: split run/dev requirements, lock versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,24 @@
-sudo: required
+sudo: false
 dist: thrusty
 language: python
 python:
+  - "2.7"
   - "3.4"
+  - "3.5"
+  - "3.6"
 
 addons:
   apt:
     packages:
-      - python-pygame
-      - mercurial
-
-before_install:
-  - sudo apt-get build-dep -y python-pygame
-  - pip install hg+http://bitbucket.org/pygame/pygame
-  - python -c "import pygame; print(pygame.__version__)"
+      - make
+      - libsdl1.2
+      - libsdl1.2-dev
 
 install:
-  - pip install -r dev-requirements.txt
-  - pip install .
+  - PYVERSION=$TRAVIS_PYTHON_VERSION make devel
 
 script:
-  - py.test --cov=./xoinvader --cov-report=xml --strict -v
+  - PYVERSION=$TRAVIS_PYTHON_VERSION COV_FMT=xml make test
 
 after_success:
   - codecov

--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,8 @@ install:
 
 devel:
 	$(VENV_CMD) $(VENV)
+	$(PIP) install -r requirements.txt
 	$(PIP) install -r dev-requirements.txt
-	$(PIP) install hg+https://bitbucket.org/pygame/pygame |:
 	$(PIP) install -e .
 
 help:

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ VENV      ?= .venv
 VENV_CMD   = virtualenv --python=python$(PYVERSION)
 PYTHON    ?= $(VENV)/bin/python$(PYVERSION)
 PYTEST     = $(VENV)/bin/py.test
+COV_FMT   ?= html
 PIP       ?= $(VENV)/bin/pip
 RM         = rm -f
 
@@ -34,7 +35,7 @@ lint-full:
 	@$(PYTEST) --pylint -m pylint -vvvv $(PYTEST_ARGS) --pylint-error-types CREWF
 
 test:
-	@$(PYTEST) --cov=./xoinvader --cov-report=html --strict -v $(PYTEST_ARGS)
+	@$(PYTEST) --cov=./xoinvader --cov-report=$(COV_FMT) --strict -v $(PYTEST_ARGS)
 
 view_cov: test
 	@xdg-open ./htmlcov/index.html

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,7 +5,5 @@ pytest
 pylint
 pytest-coverage
 pytest-pylint
-six
 sphinx
-tornado
 tox

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+six
+tornado>=4,<5
+pygame>=1.9,<2


### PR DESCRIPTION
**Closes issue(s):** [ #73 ]

**Description of the changes:**
  Tornado API was changed. In dev-requirements.txt version constraint doesn't set, so all fails.
  But good news that pygame finally can be installer from PyPI, so I added it to requirements.
 
  * What's new:
    * I splitted dev-requirements.txt to 2 files, for runtime and dev environment. `make devel` does both.
    * Container-base travis builds.
    * Multiple python versions runs tests via Makefile, beautiful.
  * Fixes:
    * Lock tornado version in [4, 5).

Some tests can fail with uninitialized application, I will investigate this later.
Python 2.7 will fail due to #75, this is ok for now.
