### PR TITLE
utils: fix wrong exception type

### DIFF
--- a/xoinvader/utils.py
+++ b/xoinvader/utils.py
@@ -6,7 +6,7 @@ import logging
 import time
 try:
     time.perf_counter
-except ImportError:
+except AttributeError:
     time.perf_counter = time.time
 
 


### PR DESCRIPTION
**Closes issue(s):** [ #74 ]

**Description of the changes:**

  * Fixes:
    Stupid dunno, typo. Must fix python2.7 build.
